### PR TITLE
Feature: Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "description": "Excel-like grid component for React with custom cell editors, performant scroll & resizable columns",
   "main": "lib/bundle.js",
+  "module": "index.js",
   "scripts": {
     "build": "webpack",
     "storybook": "start-storybook -p 6006",
@@ -20,6 +21,11 @@
     "cells",
     "scroll",
     "resizable"
+  ],
+  "files": [
+    "index.js",
+    "src",
+    "lib"
   ],
   "author": "Denis Raslov <denis.raslov@yandex.ru>",
   "license": "MIT",


### PR DESCRIPTION
Add module entry to package.json.
This way webpack or rollup can use the ES6 module instead of the transpiled ES5 version from babel which includes a lot of shimed code.
If module import is supported the `index.js` file gets imported otherwise it falls back to `lib/bundle.js` when using `require`.
This will save quite a few bytes in the final bundle.

See: https://github.com/rollup/rollup/wiki/pkg.module