### PR TITLE
Add a way to automatically focus on cell's input by single click inst…

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,12 @@ Pass `true` to reset the scroll to the top of the container. Usually, you may ne
 
 ⚠️ **IMPORTANT!** You have to pass here `true` to blur the focused cell of the table after a value of any of cells has been changed. This will ensure the correct behaviour for the table. Usually it should be passed after the `onFieldChange` callback if we are talking about [the regular pattern of usage](#the-pattern-of-regular-usage).
 
+### focusOnSingleClick
+> `boolean`
+
+> defaults to `false`
+
+By default, double clicking a cell sets the focus on the cell's input. Pass `true` if you want to set the focus on the cell's input upon single clicking it.
 
 ## Customizing cells & header content
 

--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -207,7 +207,7 @@ class SpreadsheetGrid extends React.PureComponent {
         if (!find(this.props.disabledCells, { x, y })) {
             if (!e.skipCellClick && !isEqual(this.state.focusedCell, { x, y })) {
                 this.setState({
-                    focusedCell: this.props.focusedOnClick
+                    focusedCell: this.props.focusOnSingleClick
                         ? { x, y } 
                         : e.target !== e.currentTarget ? { x, y } : null,
                     activeCell: { x, y }
@@ -312,8 +312,7 @@ SpreadsheetGrid.propTypes = Object.assign({}, tablePropTypes, {
 });
 
 SpreadsheetGrid.defaultProps = {
-    blurCurrentFocus: false,
-    focusedOnClick: false
+    blurCurrentFocus: false
 };
 
 export default SpreadsheetGrid;

--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -207,7 +207,9 @@ class SpreadsheetGrid extends React.PureComponent {
         if (!find(this.props.disabledCells, { x, y })) {
             if (!e.skipCellClick && !isEqual(this.state.focusedCell, { x, y })) {
                 this.setState({
-                    focusedCell: e.target !== e.currentTarget ? { x, y } : null,
+                    focusedCell: this.props.focusedOnClick
+                        ? { x, y } 
+                        : e.target !== e.currentTarget ? { x, y } : null,
                     activeCell: { x, y }
                 });
             }
@@ -310,7 +312,8 @@ SpreadsheetGrid.propTypes = Object.assign({}, tablePropTypes, {
 });
 
 SpreadsheetGrid.defaultProps = {
-    blurCurrentFocus: false
+    blurCurrentFocus: false,
+    focusedOnClick: false
 };
 
 export default SpreadsheetGrid;

--- a/src/kit/tablePropTypes.js
+++ b/src/kit/tablePropTypes.js
@@ -21,6 +21,7 @@ export const propTypes = {
     }),
     onCellClick: PropTypes.func,
     blurCurrentFocus: PropTypes.bool,
+    focusOnSingleClick: PropTypes.bool,
 
     // scroll
     headerHeight: PropTypes.number,

--- a/src/scrollWrapper/index.js
+++ b/src/scrollWrapper/index.js
@@ -430,7 +430,8 @@ SpreadsheetGridScrollWrapper.defaultProps = {
     headerHeight: 40,
     rowHeight: 48,
     isScrollable: true,
-    resetScroll: false
+    resetScroll: false,
+    focusOnSingleClick: false
 };
 
 export default SpreadsheetGridScrollWrapper;

--- a/stories/index.js
+++ b/stories/index.js
@@ -112,7 +112,7 @@ class DataTable extends React.PureComponent {
                     getRowKey={row => row.id}
                     rowHeight={50}
                     isColumnsResizable
-                    focusedOnClick={this.props.focusedOnClick}
+                    focusOnSingleClick={this.props.focusOnSingleClick}
                     disabledCellChecker={(row, columnId) => {
                         return columnId === 'age';
                     }}
@@ -131,4 +131,4 @@ DataTable.defaultProps = {
 storiesOf('Examples', module)
     .add('Scrollable grid', () => <DataTable rows={rows} isScrollable />)
     .add('Empty scrollable grid', () => <DataTable rows={[]} isScrollable />)
-    .add('Focus on single click', () => <DataTable rows={rows} focusedOnClick={true} isScrollable />);
+    .add('Focus on single click', () => <DataTable rows={rows} focusOnSingleClick={true} isScrollable />);

--- a/stories/index.js
+++ b/stories/index.js
@@ -112,6 +112,7 @@ class DataTable extends React.PureComponent {
                     getRowKey={row => row.id}
                     rowHeight={50}
                     isColumnsResizable
+                    focusedOnClick={this.props.focusedOnClick}
                     disabledCellChecker={(row, columnId) => {
                         return columnId === 'age';
                     }}
@@ -123,9 +124,11 @@ class DataTable extends React.PureComponent {
 }
 
 DataTable.defaultProps = {
-    isScrollable: false
+    isScrollable: false,
+    focusedOnClick: false
 };
 
 storiesOf('Examples', module)
     .add('Scrollable grid', () => <DataTable rows={rows} isScrollable />)
-    .add('Empty scrollable grid', () => <DataTable rows={[]} isScrollable />);
+    .add('Empty scrollable grid', () => <DataTable rows={[]} isScrollable />)
+    .add('Focus on single click', () => <DataTable rows={rows} focusedOnClick={true} isScrollable />);


### PR DESCRIPTION
…ead of double click.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Feature: Add a way to automatically focus on the cell's input by single click instead of the default behavior of double click.

<!-- Why are these changes necessary? -->

**Why**:

I think it is helpful for the user to see the cursor in the cell's input field (or the options in select field) by just single clicking the cell. 

<!-- How were these changes implemented? -->

I've added a way to bypass the default behavior where it is required to double click the cell before showing the cursor or focusing in the text field (or showing options in select).

I've added the prop `focusedOnClick` which accepts boolean (and has a default value `false`) that tells if `Grid` will override the default behavior.
