### PR TITLE
 Implement selectTextOnFocus prop for input

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Prop | Type | Mission
 `value` | string | The value of the input
 `placeholder` | string | Placeholder displaying when there is no value
 `focus` | bool | Should the input has focus or not
+`selectTextOnFocus` | bool | Should the input content be selected when focused or not
 `onChange` | func | Blur callback. Use it to catch a changed value
 
 Usage:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-spreadsheet-grid",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An Excel-like grid component for React with custom cell editors, performant scroll & resizable columns",
   "main": "lib/bundle.js",
   "scripts": {

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -65,7 +65,7 @@ class SpreadsheetGridInput extends React.PureComponent {
     prepareFocus(focus) {
         if (focus) {
             this.input.focus();
-            if (this.props.selectOnFocus) {
+            if (this.props.selectTextOnFocus) {
                 this.input.select();
             } else {
                 this.input.selectionStart = this.input.value.length;
@@ -97,12 +97,12 @@ SpreadsheetGridInput.propTypes = {
     ]),
     onChange: PropTypes.func,
     placeholder: PropTypes.string,
-    selectOnFocus: PropTypes.bool
+    selectTextOnFocus: PropTypes.bool
 };
 
 SpreadsheetGridInput.defaultProps = {
     value: '',
-    selectOnFocus: false
+    selectTextOnFocus: false
 };
 
 export default SpreadsheetGridInput;

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -65,7 +65,11 @@ class SpreadsheetGridInput extends React.PureComponent {
     prepareFocus(focus) {
         if (focus) {
             this.input.focus();
-            this.input.selectionStart = this.input.value.length;
+            if (this.props.selectOnFocus) {
+                this.input.select();
+            } else {
+                this.input.selectionStart = this.input.value.length;
+            }
         } else if (this.input === document.activeElement) {
             this.input.blur();
         }
@@ -92,11 +96,13 @@ SpreadsheetGridInput.propTypes = {
         PropTypes.number
     ]),
     onChange: PropTypes.func,
-    placeholder: PropTypes.string
+    placeholder: PropTypes.string,
+    selectOnFocus: PropTypes.bool
 };
 
 SpreadsheetGridInput.defaultProps = {
-    value: ''
+    value: '',
+    selectOnFocus: false
 };
 
 export default SpreadsheetGridInput;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adds optional  `selectTextOnFocus` prop to `Input` that, as the name implies if set to `true`, when the active cell's input is focused, select all text on it to easily replace it. The default value is `false`.

<!-- Why are these changes necessary? -->

**Why**: To have a more excel like behavior.

<!-- How were these changes implemented? -->